### PR TITLE
[FIX] stop retries on invalid payment data

### DIFF
--- a/app/RaisenowPaymentHandler.php
+++ b/app/RaisenowPaymentHandler.php
@@ -86,7 +86,8 @@ class RaisenowPaymentHandler
                 $e->getPayment()
             );
 
-            http_response_code(400);
+            // we can't recover from this error, so return a 200 to avoid retries
+            http_response_code(200);
         } catch (GuzzleException $e) {
             Logger::warning(
                 new LogMessage(

--- a/tests/Integration/ControllerTest.php
+++ b/tests/Integration/ControllerTest.php
@@ -74,7 +74,7 @@ class ControllerTest extends TestCase
     public function testInit__InvalidPaymentData(): void
     {
         self::post(self::getUrl(), []);
-        self::assertEquals(400, http_response_code());
+        self::assertEquals(200, http_response_code());
     }
 
     public function testInit__InvalidLanguage(): void
@@ -82,7 +82,7 @@ class ControllerTest extends TestCase
         $data = self::getWebhookData();
         $data['data']['language'] = null;
         self::post(self::getUrl(), $data);
-        self::assertEquals(400, http_response_code());
+        self::assertEquals(200, http_response_code());
     }
 
     private static function getUrl(): string


### PR DESCRIPTION
We won't be able to recover if RaiseNow sends us invalid payment data. Let's therefore just report it to the admin and the accountant but return a status code 200 to RaiseNow, so RaiseNow doesn't retry.