### PR TITLE
Dev

### DIFF
--- a/.docker/php.ini
+++ b/.docker/php.ini
@@ -10,7 +10,7 @@ error_log = /dev/stderr
 error_reporting = E_ALL
 
 ; xdebug
-; xdebug.log = /dev/stderr
+xdebug.log=/tmp/xdebug.log
 xdebug.mode = develop,debug
 xdebug.discover_client_host = 1
 xdebug.client_host = host.docker.internal

--- a/.docker/php.ini
+++ b/.docker/php.ini
@@ -13,6 +13,7 @@ error_reporting = E_ALL
 ; xdebug.log = /dev/stderr
 xdebug.mode = develop,debug
 xdebug.discover_client_host = 1
+xdebug.client_host = host.docker.internal
 
 ; enable if your IDE does not set the needed params
 ; https://xdebug.org/docs/step_debug#activate_debugger

--- a/app/Client/WeblingAPI.php
+++ b/app/Client/WeblingAPI.php
@@ -12,6 +12,7 @@ use RaiseNowConnector\Exception\ConfigException;
 use RaiseNowConnector\Exception\PersistanceException;
 use RaiseNowConnector\Exception\WeblingAccountingConfigException;
 use RaiseNowConnector\Exception\WeblingAPIException;
+use RaiseNowConnector\Exception\WeblingMissingAccountingPeriodException;
 use RaiseNowConnector\Model\RaisenowPaymentData;
 use RaiseNowConnector\Model\WeblingAccountingConfig;
 use RaiseNowConnector\Util\ClientFactory;
@@ -83,6 +84,8 @@ class WeblingAPI
     /**
      * @throws ConfigException
      * @throws GuzzleException
+     * @throws WeblingAPIException
+     * @throws WeblingMissingAccountingPeriodException
      */
     private function getPeriodId(DateTimeInterface $date): int
     {
@@ -116,7 +119,7 @@ class WeblingAPI
         }
 
         if (count($data['objects']) !== 1) {
-            throw new WeblingAPIException("No accounting period found in Webling for {$date->format(DATE_ATOM)}");
+            throw new WeblingMissingAccountingPeriodException("No accounting period found in Webling for {$date->format(DATE_ATOM)}");
         }
 
         $periodId = $data['objects'][0];
@@ -129,6 +132,8 @@ class WeblingAPI
     /**
      * @throws ConfigException
      * @throws GuzzleException
+     * @throws WeblingAPIException
+     * @throws WeblingMissingAccountingPeriodException
      */
     public function addPayment(mixed $memberId, RaisenowPaymentData $payment): void
     {
@@ -175,6 +180,8 @@ class WeblingAPI
     /**
      * @throws ConfigException
      * @throws GuzzleException
+     * @throws WeblingAPIException
+     * @throws WeblingMissingAccountingPeriodException
      */
     private function obtainAccountingConfig(DateTimeInterface $date): WeblingAccountingConfig
     {

--- a/app/Exception/WeblingMissingAccountingPeriodException.php
+++ b/app/Exception/WeblingMissingAccountingPeriodException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace RaiseNowConnector\Exception;
+
+use RuntimeException;
+
+class WeblingMissingAccountingPeriodException extends RuntimeException
+{
+
+}

--- a/app/WeblingPaymentProcessor.php
+++ b/app/WeblingPaymentProcessor.php
@@ -9,6 +9,8 @@ use JsonException;
 use RaiseNowConnector\Client\WeblingAPI;
 use RaiseNowConnector\Exception\ConfigException;
 use RaiseNowConnector\Exception\RaisenowPaymentDataException;
+use RaiseNowConnector\Exception\WeblingAPIException;
+use RaiseNowConnector\Exception\WeblingMissingAccountingPeriodException;
 use RaiseNowConnector\Model\RaisenowPaymentData;
 use RaiseNowConnector\Model\WeblingPaymentState;
 use RaiseNowConnector\Util\Logger;
@@ -35,6 +37,8 @@ class WeblingPaymentProcessor
      * @throws JsonException
      * @throws RaisenowPaymentDataException
      * @throws GuzzleException
+     * @throws WeblingAPIException
+     * @throws WeblingMissingAccountingPeriodException
      * @noinspection PhpDocRedundantThrowsInspection
      */
     public function process(): WeblingPaymentState
@@ -85,6 +89,8 @@ class WeblingPaymentProcessor
      *
      * @throws ConfigException
      * @throws GuzzleException
+     * @throws WeblingAPIException
+     * @throws WeblingMissingAccountingPeriodException
      */
     private function addPaymentToWebling(): bool
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - .docker/php.ini:/usr/local/etc/php/php.ini
     depends_on:
       - mailhog
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   mailhog:
     image: mailhog/mailhog

--- a/tests/Integration/ControllerTest.php
+++ b/tests/Integration/ControllerTest.php
@@ -449,4 +449,21 @@ class ControllerTest extends TestCase
         self::post(self::getUrl(), self::getWebhookData());
         self::assertEquals(502, http_response_code());
     }
+
+    public function testInit__MissingPaymentPeriod(): void
+    {
+        $this->mockWeblingServiceTokenRequest();
+        $this->mockWeblingServiceMatchUpdateGetMemberRequest();
+        ClientFactory::queueMockHandler(
+            new MockHandler([
+                // get period id
+                self::createResponse(200, ['objects' => []]),
+
+                // fail on further requests
+                self::createResponse(500, []),
+            ])
+        );
+        self::post(self::getUrl(), self::getWebhookData());
+        self::assertEquals(503, http_response_code());
+    }
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -4,6 +4,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          bootstrap="./bootstrap.php"
+         stderr="true"
 >
     <testsuites>
         <testsuite name="Integration Tests">


### PR DESCRIPTION
* gracefully handle missing accounting period (in Webling)
* fix: lost log entry on unspecific error
* add xdebug config for mac
* log test output to stderr (so we don't conflict with already sent headers)
* log xdebug output to /tmp/xdebug.log to not pollute test output